### PR TITLE
fix: tolerate IPv6 being unavailable on the host

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `UDPSender` is implemented as a Go class using idiomatic Go patterns: structs with methods, interfaces, and proper encapsulation. The key design feature is **per-packet source and destination address specification**, allowing complete dynamic control of both source and destination IP and port for each transmitted packet. The implementation supports both IPv4 and IPv6 through separate raw sockets.
+The `UDPSender` is implemented as a Go class using idiomatic Go patterns: structs with methods, interfaces, and proper encapsulation. The key design feature is **per-packet source and destination address specification**, allowing complete dynamic control of both source and destination IP and port for each transmitted packet. The implementation supports both IPv4 and IPv6 through separate raw sockets. IPv6 support is optional - if IPv6 is unavailable on the host, the sender will operate in IPv4-only mode.
 
 ```mermaid
 graph TD
@@ -107,7 +107,7 @@ Benefits:
 - Validation before object creation
 - Complex initialization logic
 - Returns errors instead of invalid objects
-- Resource acquisition (creates both IPv4 and IPv6 raw sockets)
+- Resource acquisition (creates IPv4 raw socket, IPv6 socket if available)
 - MTU configuration for payload validation
 - No destination needed (both source and destination specified per packet)
 
@@ -229,7 +229,8 @@ graph TB
 maxPayloadIPv4 := 1500 - 20 - 8  // 1472 bytes
 maxPayloadIPv6 := 1500 - 40 - 8  // 1452 bytes
 
-// Create sender with MTU-based payload limits (creates both IPv4 and IPv6 sockets)
+// Create sender with MTU-based payload limits
+// Creates IPv4 socket (required) and IPv6 socket (if available)
 sender, err := NewUDPSender(maxPayloadIPv4, maxPayloadIPv6)
 if err != nil {
     log.Fatal(err)
@@ -253,7 +254,7 @@ sender.Send("Packet 1", net.ParseIP("10.0.0.1"), 5001, net.ParseIP("192.168.1.10
 sender.Send("Packet 2", net.ParseIP("10.0.0.2"), 5002, net.ParseIP("192.168.1.101"), 514)
 sender.Send("Packet 3", net.ParseIP("192.168.1.5"), 6000, net.ParseIP("10.0.0.1"), 8080)
 
-// IPv6 works too
+// IPv6 works too (if available on the host)
 sender.Send("IPv6 Packet", net.ParseIP("2001:db8::1"), 5000, net.ParseIP("2001:db8::100"), 8080)
 ```
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -46,6 +46,11 @@ func hasIPv6() bool {
 	}
 	defer func() { _ = sender.Close() }()
 
+	// Check if the sender actually has an IPv6 socket
+	if sender.fdIPv6 < 0 {
+		return false
+	}
+
 	// Try sending a small test packet to ::1 (localhost)
 	srcIP := net.ParseIP("::1")
 	destIP := net.ParseIP("::1")

--- a/sender.go
+++ b/sender.go
@@ -89,6 +89,11 @@ func (s *UDPSender) Send(message string, srcIP net.IP, srcPort uint16, destIP ne
 	isSrcIPv4 := srcIPv4 != nil
 	isDestIPv4 := destIPv4 != nil
 
+	// Check IPv6 availability early
+	if !isSrcIPv4 && !isDestIPv4 && s.fdIPv6 < 0 {
+		return 0, fmt.Errorf("IPv6 is not available on this system")
+	}
+
 	// Validate payload size against MTU limits
 	maxPayload := s.maxPayloadIPv4
 	ipVersion := "IPv4"
@@ -121,11 +126,6 @@ func (s *UDPSender) Send(message string, srcIP net.IP, srcPort uint16, destIP ne
 
 	// Check if both are IPv6
 	if !isSrcIPv4 && !isDestIPv4 {
-		// Check if IPv6 is available
-		if s.fdIPv6 < 0 {
-			return 0, fmt.Errorf("IPv6 is not available on this system")
-		}
-
 		// Use IPv6
 		packet := s.buildPacket(payload, srcIP, srcPort, destIP, destPort)
 

--- a/sender.go
+++ b/sender.go
@@ -29,7 +29,7 @@ var _ PacketSender = (*UDPSender)(nil)
 // NewUDPSender creates a new UDP sender with raw socket support
 // Both source and destination IP and port are specified per-packet in the Send() method
 // Requires root/admin privileges to create raw sockets
-// Supports both IPv4 and IPv6
+// Supports both IPv4 and IPv6 (IPv6 is optional - if unavailable, only IPv4 will work)
 // maxPayloadIPv4 and maxPayloadIPv6 specify the maximum payload sizes based on MTU
 func NewUDPSender(maxPayloadIPv4, maxPayloadIPv6 int) (*UDPSender, error) {
 	sender := &UDPSender{
@@ -54,17 +54,16 @@ func NewUDPSender(maxPayloadIPv4, maxPayloadIPv6 int) (*UDPSender, error) {
 
 	sender.fdIPv4 = fd4
 
-	// Create IPv6 socket
+	// Create IPv6 socket (optional - failure is tolerated)
 	fd6, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
 	if err != nil {
-		// Clean up IPv4 socket
-		_ = syscall.Close(sender.fdIPv4)
-		return nil, fmt.Errorf("failed to create raw IPv6 socket (requires root): %w", err)
+		// IPv6 not available - this is acceptable, just log and continue with IPv4 only
+		// The sender will return an error if someone tries to send IPv6 packets
+	} else {
+		// Note: IPv6 raw sockets don't require IPV6_HDRINCL on most systems
+		// The kernel automatically sets the next header field
+		sender.fdIPv6 = fd6
 	}
-	// Note: IPv6 raw sockets don't require IPV6_HDRINCL on most systems
-	// The kernel automatically sets the next header field
-
-	sender.fdIPv6 = fd6
 
 	return sender, nil
 }
@@ -122,6 +121,11 @@ func (s *UDPSender) Send(message string, srcIP net.IP, srcPort uint16, destIP ne
 
 	// Check if both are IPv6
 	if !isSrcIPv4 && !isDestIPv4 {
+		// Check if IPv6 is available
+		if s.fdIPv6 < 0 {
+			return 0, fmt.Errorf("IPv6 is not available on this system")
+		}
+
 		// Use IPv6
 		packet := s.buildPacket(payload, srcIP, srcPort, destIP, destPort)
 

--- a/sender.go
+++ b/sender.go
@@ -57,7 +57,7 @@ func NewUDPSender(maxPayloadIPv4, maxPayloadIPv6 int) (*UDPSender, error) {
 	// Create IPv6 socket (optional - failure is tolerated)
 	fd6, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
 	if err != nil {
-		// IPv6 not available - this is acceptable, just log and continue with IPv4 only
+		// IPv6 not available - continue with IPv4 only
 		// The sender will return an error if someone tries to send IPv6 packets
 	} else {
 		// Note: IPv6 raw sockets don't require IPV6_HDRINCL on most systems

--- a/sender_test.go
+++ b/sender_test.go
@@ -22,12 +22,16 @@ func TestNewUDPSender(t *testing.T) {
 	}
 	defer func() { _ = sender.Close() }()
 
-	// Verify both socket file descriptors are valid
+	// Verify IPv4 socket file descriptor is valid (required)
 	if sender.fdIPv4 < 0 {
 		t.Error("IPv4 socket file descriptor is invalid")
 	}
+
+	// IPv6 socket is optional - log whether it's available
 	if sender.fdIPv6 < 0 {
-		t.Error("IPv6 socket file descriptor is invalid")
+		t.Log("IPv6 socket not available (this is acceptable)")
+	} else {
+		t.Log("IPv6 socket is available")
 	}
 }
 
@@ -206,6 +210,20 @@ func TestUDPSender_Send_ErrorCases(t *testing.T) {
 				t.Error("Expected error, got nil")
 			} else if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("Expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+
+	// Test IPv6 unavailable error separately, only if IPv6 is not available
+	if sender.fdIPv6 < 0 {
+		t.Run("IPv6 unavailable", func(t *testing.T) {
+			srcIP := net.ParseIP("2001:db8::1")
+			destIP := net.ParseIP("2001:db8::2")
+			_, err := sender.Send("test", srcIP, 1234, destIP, 53)
+			if err == nil {
+				t.Error("Expected error for IPv6 when unavailable, got nil")
+			} else if !strings.Contains(err.Error(), "IPv6 is not available") {
+				t.Errorf("Expected 'IPv6 is not available' error, got %q", err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #17

The sender now gracefully handles systems where IPv6 is unavailable or disabled. Previously, NewUDPSender() would fail completely if IPv6 socket creation failed, preventing the application from starting even for IPv4-only workloads.

Changes:
- Modified NewUDPSender() to make IPv6 socket creation optional
- Added check in Send() to return clear error when IPv6 packets are requested but IPv6 is unavailable
- Updated tests to handle optional IPv6 support
- Updated documentation to reflect IPv6 as optional feature

The sender now operates in IPv4-only mode when IPv6 is unavailable while maintaining full functionality when both protocols are supported.