### PR TITLE
fix: remove CGO dependency (closes #20)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ This directory contains GitHub Actions workflows for CI/CD.
 
 **Jobs**:
 
-- **Test**: Runs tests on Go 1.21 and 1.22
+- **Test**: Runs tests on Go 1.24 and 1.25
 - **Build**: Verifies the project builds successfully
 - **Lint**: Runs golangci-lint for code quality
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v4
       with:
-        version: latest
+        version: v1.64.8
 
   benchmark:
     name: Benchmark (Unit Tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
         go-version: '1.24'
 
     - name: Build
+      env:
+        CGO_ENABLED: 0
       run: go build -v ./...
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.24', '1.25']
     
     steps:
     - name: Checkout code
@@ -54,7 +54,7 @@ jobs:
     name: Integration Tests (With Raw Socket Capabilities)
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21
+      image: golang:1.24
       options: --cap-add=NET_RAW --cap-add=NET_ADMIN
     
     steps:
@@ -89,7 +89,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.24'
 
     - name: Build
       run: go build -v ./...
@@ -105,7 +105,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.24'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v4
@@ -123,7 +123,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.24'
 
     - name: Run benchmarks (short mode - no root)
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.24'
 
     - name: Run tests
       run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,16 +106,16 @@ jobs:
         mkdir -p dist
         
         # Build for Linux x64
-        GOOS=linux GOARCH=amd64 go build -o dist/udp-sender-linux-x64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/udp-sender-linux-x64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
         
         # Build for Linux ARM64
-        GOOS=linux GOARCH=arm64 go build -o dist/udp-sender-linux-arm64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/udp-sender-linux-arm64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
         
         # Build for macOS x64
-        GOOS=darwin GOARCH=amd64 go build -o dist/udp-sender-darwin-x64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
+        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o dist/udp-sender-darwin-x64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
         
         # Build for macOS ARM64 (Apple Silicon)
-        GOOS=darwin GOARCH=arm64 go build -o dist/udp-sender-darwin-arm64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
+        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o dist/udp-sender-darwin-arm64 -ldflags="-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" .
 
     - name: Create compressed archives and checksums
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /build
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION ?= dev
 
 # Build the application
 build:
-	go build -ldflags="-X main.Version=$(VERSION)" -o udp-sender .
+	CGO_ENABLED=0 go build -ldflags="-s -w -X main.Version=$(VERSION)" -o udp-sender .
 
 # Run tests (without root - some tests will skip)
 test:

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ coverage-root:
 lint:
 	@GOLANGCI_LINT=$$(command -v golangci-lint 2>/dev/null || echo "$$(go env GOPATH)/bin/golangci-lint"); \
 	if [ ! -x "$$GOLANGCI_LINT" ]; then \
-		echo "golangci-lint not found. Installing v1.62.2..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.62.2; \
+		echo "golangci-lint not found. Installing v1.64.8..."; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.64.8; \
 		GOLANGCI_LINT="$$(go env GOPATH)/bin/golangci-lint"; \
 	fi; \
 	$$GOLANGCI_LINT run

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Go application for sending UDP packets with raw socket support, allowing IP an
 
 ### System Requirements
 
-- Go 1.21 or later
+- Go 1.24 or later
 - **Root/Administrator privileges** or **`CAP_NET_RAW`** (required for raw socket creation)
 - IPv4/6 network support
 
@@ -487,7 +487,7 @@ The project uses GitHub Actions for continuous integration:
 
 ### Workflows
 
-- **Test Job**: Runs on Go 1.21 and 1.22
+- **Test Job**: Runs on Go 1.24 and 1.25
   - Note: Root-required tests are skipped in CI
 - **Build Job**: Verifies compilation
 - **Lint Job**: Runs golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/criblio/udp-sender
 
-go 1.21
+go 1.24


### PR DESCRIPTION
the pre-built binary can't run on RHEL 8 due to go's net package pulling in CGO by default for dns resolution, which links against glibc. RHEL 8 ships glibc 2.28 but the GH build box had 2.32/2.34 - so the binary just refused to start.

fix is simple - set CGO_ENABLED=0 in the Makefile build target so we get a fully static binary with no glibc dependency. also added -s -w ldflags to strip debug info (matching what the Dockerfile already does) and bumped go to 1.24 across the board.

tested on arm and x86_64 on macos, alpine, debian, and rocky linux 8 (glibc 2.28) with CGO_ENABLED=0 -- all tests pass